### PR TITLE
merge v0.1.22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Versioning].
 
 ## [Unreleased] <!-- #release:date -->
 
+* Incorporate unreleased patch from upstream to fix the handling of time.h
+  header inclusions. This fixes compliation with GCC 14+.
+
 ## [0.1.20] - 2022-05-26
 
 * Upgrade to libsasl2 v2.1.28.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ Versioning].
 
 ## [Unreleased] <!-- #release:date -->
 
+* Ignore the `CONFIG_SITE` environment variable when running configuration.
+  Site-specific configuration is generally not relevant when building with
+  Cargo and can lead to installations that are not laid out in the way
+  this crate's build script expects. See [#49] for details.
+
 ## [0.1.21] - 2024-05-13
 
 * Incorporate unreleased patch from upstream to fix the handling of time.h
@@ -197,6 +202,7 @@ Initial release.
 [#34]: https://github.com/MaterializeInc/rust-sasl/issues/34
 [#36]: https://github.com/MaterializeInc/rust-sasl/issues/36
 [#40]: https://github.com/MaterializeInc/rust-sasl/issues/40
+[#49]: https://github.com/MaterializeInc/rust-sasl/pull/49
 
 [@pbor]: https://github.com/pbor
 [@sandhose]: https://github.com/sandhose

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Versioning].
 
 ## [Unreleased] <!-- #release:date -->
 
+## [0.1.22] - 2024-05-13
+
 * Ignore the `CONFIG_SITE` environment variable when running configuration.
   Site-specific configuration is generally not relevant when building with
   Cargo and can lead to installations that are not laid out in the way
@@ -168,7 +170,8 @@ Versioning].
 Initial release.
 
 <!-- #release:next-url -->
-[Unreleased]: https://github.com/MaterializeInc/rust-sasl/compare/v0.1.21...HEAD
+[Unreleased]: https://github.com/MaterializeInc/rust-sasl/compare/v0.1.22...HEAD
+[0.1.22]: https://github.com/MaterializeInc/rust-sasl/compare/v0.1.21...v0.1.22
 [0.1.21]: https://github.com/MaterializeInc/rust-sasl/compare/v0.1.20...v0.1.21
 [0.1.20]: https://github.com/MaterializeInc/rust-sasl/compare/v0.1.19+2.1.27...v0.1.20
 [0.1.19+2.1.27]: https://github.com/MaterializeInc/rust-sasl/compare/v0.1.18...v0.1.19+2.1.27

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Versioning].
 
 ## [Unreleased] <!-- #release:date -->
 
+## [0.1.21] - 2024-05-13
+
 * Incorporate unreleased patch from upstream to fix the handling of time.h
   header inclusions. This fixes compliation with GCC 14+.
 
@@ -161,7 +163,8 @@ Versioning].
 Initial release.
 
 <!-- #release:next-url -->
-[Unreleased]: https://github.com/MaterializeInc/rust-sasl/compare/v0.1.20...HEAD
+[Unreleased]: https://github.com/MaterializeInc/rust-sasl/compare/v0.1.21...HEAD
+[0.1.21]: https://github.com/MaterializeInc/rust-sasl/compare/v0.1.20...v0.1.21
 [0.1.20]: https://github.com/MaterializeInc/rust-sasl/compare/v0.1.19+2.1.27...v0.1.20
 [0.1.19+2.1.27]: https://github.com/MaterializeInc/rust-sasl/compare/v0.1.18...v0.1.19+2.1.27
 [0.1.18]: https://github.com/MaterializeInc/rust-sasl/compare/v0.1.17...v0.1.18

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@
 ```toml
 # Cargo.toml
 [dependencies]
-sasl2-sys = "0.1.20"
+sasl2-sys = "0.1.21"
 ```
 
 [Cyrus SASL]: https://www.cyrusimap.org/sasl/
-[docs]: https://docs.rs/sasl2-sys/0.1.20/sasl2-sys
+[docs]: https://docs.rs/sasl2-sys/0.1.21/sasl2-sys

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@
 ```toml
 # Cargo.toml
 [dependencies]
-sasl2-sys = "0.1.21"
+sasl2-sys = "0.1.22"
 ```
 
 [Cyrus SASL]: https://www.cyrusimap.org/sasl/
-[docs]: https://docs.rs/sasl2-sys/0.1.21/sasl2-sys
+[docs]: https://docs.rs/sasl2-sys/0.1.22/sasl2-sys

--- a/release.toml
+++ b/release.toml
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+consolidate-commits = false
 tag-prefix = ""
 pre-release-commit-message = "{{crate_name}}: release {{version}}"
 pre-release-replacements = [

--- a/sasl2-sys/Cargo.toml
+++ b/sasl2-sys/Cargo.toml
@@ -7,7 +7,7 @@ documentation = "https://docs.rs/sasl2-sys"
 repository = "https://github.com/MaterializeInc/rust-sasl"
 license = "Apache-2.0"
 categories = ["external-ffi-bindings"]
-version = "0.1.21+2.1.28"
+version = "0.1.22+2.1.28"
 edition = "2018"
 links = "sasl2"
 

--- a/sasl2-sys/Cargo.toml
+++ b/sasl2-sys/Cargo.toml
@@ -7,7 +7,7 @@ documentation = "https://docs.rs/sasl2-sys"
 repository = "https://github.com/MaterializeInc/rust-sasl"
 license = "Apache-2.0"
 categories = ["external-ffi-bindings"]
-version = "0.1.20+2.1.28"
+version = "0.1.21+2.1.28"
 edition = "2018"
 links = "sasl2"
 

--- a/sasl2-sys/build.rs
+++ b/sasl2-sys/build.rs
@@ -122,6 +122,7 @@ fn build_sasl(metadata: &Metadata) {
     }
     cmd(src_dir.join("configure"), &configure_args)
         .dir(&src_dir)
+        .env_remove("CONFIG_SITE")
         .run()
         .expect("configure failed");
 

--- a/sasl2-sys/patch/09-time-h.patch
+++ b/sasl2-sys/patch/09-time-h.patch
@@ -1,0 +1,57 @@
+From 399625c3413c313e93432d0f5907350722b861c7 Mon Sep 17 00:00:00 2001
+From: Sam James <sam@gentoo.org>
+Date: Wed, 23 Feb 2022 00:45:15 +0000
+Subject: [PATCH] Fix <time.h> check
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+We're conditionally including based on HAVE_TIME_H in a bunch of places,
+but we're not actually checking for time.h, so that's never going to be defined.
+
+While at it, add in a missing include in the cram plugin.
+
+This fixes a bunch of implicit declaration warnings:
+```
+ * cyrus-sasl-2.1.28/lib/saslutil.c:280:3: warning: implicit declaration of function ‘time’ [-Wimplicit-function-declaration]
+ * cyrus-sasl-2.1.28/lib/saslutil.c:364:41: warning: implicit declaration of function ‘clock’ [-Wimplicit-function-declaration]
+ * cyrus-sasl-2.1.28/plugins/cram.c:132:7: warning: implicit declaration of function ‘time’ [-Wimplicit-function-declaration]
+ * cyrus-sasl-2.1.28/lib/saslutil.c:280:3: warning: implicit declaration of function ‘time’ [-Wimplicit-function-declaration]
+ * cyrus-sasl-2.1.28/lib/saslutil.c:364:41: warning: implicit declaration of function ‘clock’ [-Wimplicit-function-declaration]
+ * cyrus-sasl-2.1.28/plugins/cram.c:132:7: warning: implicit declaration of function ‘time’ [-Wimplicit-function-declaration]
+```
+
+Signed-off-by: Sam James <sam@gentoo.org>
+---
+ configure.ac   | 2 +-
+ plugins/cram.c | 4 ++++
+ 2 files changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/configure.ac b/configure.ac
+index e1bf53b6..ad781830 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -1290,7 +1290,7 @@ AC_CHECK_HEADERS_ONCE([sys/time.h])
+
+ AC_HEADER_DIRENT
+ AC_HEADER_SYS_WAIT
+-AC_CHECK_HEADERS(crypt.h des.h dlfcn.h fcntl.h limits.h malloc.h paths.h strings.h sys/file.h sys/time.h syslog.h unistd.h inttypes.h sys/uio.h sys/param.h sysexits.h stdarg.h varargs.h krb5.h)
++AC_CHECK_HEADERS(crypt.h des.h dlfcn.h fcntl.h limits.h malloc.h paths.h strings.h sys/file.h sys/time.h syslog.h time.h unistd.h inttypes.h sys/uio.h sys/param.h sysexits.h stdarg.h varargs.h krb5.h)
+
+ IPv6_CHECK_SS_FAMILY()
+ IPv6_CHECK_SA_LEN()
+diff --git a/plugins/cram.c b/plugins/cram.c
+index d02e9baa..695aaa91 100644
+--- a/plugins/cram.c
++++ b/plugins/cram.c
+@@ -53,6 +53,10 @@
+ #endif
+ #include <fcntl.h>
+
++#ifdef HAVE_TIME_H
++#include <time.h>
++#endif
++
+ #include <sasl.h>
+ #include <saslplug.h>
+ #include <saslutil.h>

--- a/sasl2-sys/sasl2/config.h.in
+++ b/sasl2-sys/sasl2/config.h.in
@@ -366,6 +366,9 @@
 /* Define to 1 if you have <sys/wait.h> that is POSIX.1 compatible. */
 #undef HAVE_SYS_WAIT_H
 
+/* Define to 1 if you have the <time.h> header file. */
+#undef HAVE_TIME_H
+
 /* Define to 1 if you have the <unistd.h> header file. */
 #undef HAVE_UNISTD_H
 

--- a/sasl2-sys/sasl2/configure
+++ b/sasl2-sys/sasl2/configure
@@ -22174,6 +22174,12 @@ then :
   printf "%s\n" "#define HAVE_SYSLOG_H 1" >>confdefs.h
 
 fi
+ac_fn_c_check_header_compile "$LINENO" "time.h" "ac_cv_header_time_h" "$ac_includes_default"
+if test "x$ac_cv_header_time_h" = xyes
+then :
+  printf "%s\n" "#define HAVE_TIME_H 1" >>confdefs.h
+
+fi
 ac_fn_c_check_header_compile "$LINENO" "unistd.h" "ac_cv_header_unistd_h" "$ac_includes_default"
 if test "x$ac_cv_header_unistd_h" = xyes
 then :

--- a/sasl2-sys/sasl2/configure.ac
+++ b/sasl2-sys/sasl2/configure.ac
@@ -1233,7 +1233,7 @@ AC_CHECK_HEADERS_ONCE([sys/time.h])
 
 AC_HEADER_DIRENT
 AC_HEADER_SYS_WAIT
-AC_CHECK_HEADERS(crypt.h des.h dlfcn.h fcntl.h limits.h malloc.h paths.h strings.h sys/file.h sys/time.h syslog.h unistd.h inttypes.h sys/uio.h sys/param.h sysexits.h stdarg.h varargs.h krb5.h)
+AC_CHECK_HEADERS(crypt.h des.h dlfcn.h fcntl.h limits.h malloc.h paths.h strings.h sys/file.h sys/time.h syslog.h time.h unistd.h inttypes.h sys/uio.h sys/param.h sysexits.h stdarg.h varargs.h krb5.h)
 
 IPv6_CHECK_SS_FAMILY()
 IPv6_CHECK_SA_LEN()

--- a/sasl2-sys/sasl2/plugins/cram.c
+++ b/sasl2-sys/sasl2/plugins/cram.c
@@ -53,6 +53,10 @@
 #endif
 #include <fcntl.h>
 
+#ifdef HAVE_TIME_H
+#include <time.h>
+#endif
+
 #include <sasl.h>
 #include <saslplug.h>
 #include <saslutil.h>


### PR DESCRIPTION
since doing some system updates, i can no longer compile sasl2-sys on my laptop (probably the gcc-14+ issue mentioned in the changelog).
The current latest (v0.1.22) seems to work fine for me